### PR TITLE
Move Devel::PPPort to configure requires

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,6 +32,7 @@ WriteMakefile1(
 
     CONFIGURE_REQUIRES => {
         'ExtUtils::MakeMaker' => 7.12,
+        'Devel::PPPort' => 0,
     },
 
     # Because of X::Tiny
@@ -43,10 +44,6 @@ WriteMakefile1(
         'Text::Control' => 0,
         'Types::Serialiser' => 0,
         'XSLoader' => 0.24,
-    },
-
-    BUILD_REQUIRES => {
-        'Devel::PPPort' => 0,
     },
 
     TEST_REQUIRES => {


### PR DESCRIPTION
As it is used in Makefile.PL itself, the requirement on Devel::PPPort should be in the configure phase, not build.