### PR TITLE
Add opt-in duplicate map key rejection

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module CBOR::Free
 
+0.33 (unreleased)
+- Add opt-in rejection of duplicate map keys to the object and sequence
+  decoders.
+
 0.32 4 March 2022
 - Fix compatibility with big-endian systems.
 - Add Test::Pod requirement for testing.

--- a/Free.xs
+++ b/Free.xs
@@ -294,6 +294,14 @@ naive_utf8(decode_ctx* decode_state, SV* new_setting = NULL)
     OUTPUT:
         RETVAL
 
+bool
+reject_duplicate_keys(decode_ctx* decode_state, SV* new_setting = NULL)
+    CODE:
+        RETVAL = _handle_flag_call( aTHX_ decode_state, new_setting, CBF_FLAG_REJECT_DUPLICATE_KEYS );
+
+    OUTPUT:
+        RETVAL
+
 SV *
 string_decode_cbor(SV* self)
     CODE:
@@ -387,6 +395,14 @@ bool
 naive_utf8(seqdecode_ctx* seqdecode, SV* new_setting = NULL)
     CODE:
         RETVAL = _handle_flag_call( aTHX_ seqdecode->decode_state, new_setting, CBF_FLAG_NAIVE_UTF8 );
+
+    OUTPUT:
+        RETVAL
+
+bool
+reject_duplicate_keys(seqdecode_ctx* seqdecode, SV* new_setting = NULL)
+    CODE:
+        RETVAL = _handle_flag_call( aTHX_ seqdecode->decode_state, new_setting, CBF_FLAG_REJECT_DUPLICATE_KEYS );
 
     OUTPUT:
         RETVAL

--- a/MANIFEST
+++ b/MANIFEST
@@ -30,6 +30,7 @@ lib/CBOR/Free/Tagged.pm
 lib/CBOR/Free/X.pm
 lib/CBOR/Free/X/Base.pm
 lib/CBOR/Free/X/CannotDecode64Bit.pm
+lib/CBOR/Free/X/DuplicateMapKey.pm
 lib/CBOR/Free/X/Incomplete.pm
 lib/CBOR/Free/X/InvalidControl.pm
 lib/CBOR/Free/X/InvalidMapKey.pm
@@ -48,6 +49,7 @@ t/config.t
 t/dec_strings.t
 t/decode.t
 t/decode_map_keys.t
+t/duplicate_map_keys.t
 t/encode_modes.t
 t/errors.t
 t/examples.t

--- a/README.md
+++ b/README.md
@@ -171,7 +171,9 @@ CBOR binary strings become undecoded Perl strings.
 An exception is thrown if the decoder finds anything else as a map key.
 Note that, because Perl does not distinguish between binary and text strings,
 if two keys of the same map contain the same bytes, Perl will consider these
-a duplicate key and prefer the latter.
+a duplicate key and prefer the latter. Use `reject_duplicate_keys()` on
+[`CBOR::Free::Decoder`](https://metacpan.org/pod/CBOR%3A%3AFree%3A%3ADecoder)
+to reject map keys that would overwrite an earlier key.
 - CBOR booleans become the corresponding [Types::Serialiser](https://metacpan.org/pod/Types%3A%3ASerialiser) values.
 Both CBOR null and undefined become Perl undef.
 - [CBOR’s “indirection” tag](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) is interpreted as a scalar reference. This behavior is always

--- a/cbor_free_decode.c
+++ b/cbor_free_decode.c
@@ -174,6 +174,19 @@ void _croak_invalid_map_key( pTHX_ decode_ctx* decstate ) {
     assert(0);
 }
 
+void _croak_duplicate_map_key( pTHX_ decode_ctx* decstate, UV offset ) {
+    _free_decode_state_if_not_persistent(aTHX_ decstate);
+
+    SV* args[2] = {
+        newSVpvs("DuplicateMapKey"),
+        newSVuv(offset),
+    };
+
+    cbf_die_with_arguments( aTHX_ 2, args );
+
+    assert(0);
+}
+
 void _croak_cannot_decode_64bit( pTHX_ decode_ctx* decstate ) {
     UV offset = decstate->curbyte - decstate->start;
 
@@ -438,6 +451,8 @@ bool _decode_str( pTHX_ decode_ctx* decstate, union numbuf_or_sv* string_u ) {
 void _decode_hash_entry( pTHX_ decode_ctx* decstate, HV *hash ) {
     _RETURN_IF_INCOMPLETE( decstate, 1,  );
 
+    UV key_offset = decstate->curbyte - decstate->start;
+
     union numbuf_or_sv my_key;
     my_key.numbuf.buffer = NULL;
 
@@ -497,6 +512,20 @@ void _decode_hash_entry( pTHX_ decode_ctx* decstate, HV *hash ) {
         default:
             _croak_invalid_map_key( aTHX_ decstate);
             return; // Silence compiler warning.
+    }
+
+    if (decstate->flags & CBF_FLAG_REJECT_DUPLICATE_KEYS) {
+        bool duplicate = my_key_has_sv
+            ? hv_exists_ent(hash, my_key.sv, 0)
+            : hv_exists(hash, keystr, keylen);
+
+        if (duplicate) {
+            if (my_key_has_sv) {
+                SvREFCNT_dec( my_key.sv );
+            }
+
+            _croak_duplicate_map_key( aTHX_ decstate, key_offset );
+        }
     }
 
     SV *curval = cbf_decode_one( aTHX_ decstate );

--- a/cbor_free_decode.h
+++ b/cbor_free_decode.h
@@ -7,6 +7,7 @@
 #define CBF_FLAG_PRESERVE_REFERENCES 1
 #define CBF_FLAG_NAIVE_UTF8 2
 #define CBF_FLAG_PERSIST_STATE 4
+#define CBF_FLAG_REJECT_DUPLICATE_KEYS 8
 
 //----------------------------------------------------------------------
 // Definitions

--- a/lib/CBOR/Free.pm
+++ b/lib/CBOR/Free.pm
@@ -226,7 +226,9 @@ use case is legitimate and potentially gainful.
 An exception is thrown if the decoder finds anything else as a map key.
 Note that, because Perl does not distinguish between binary and text strings,
 if two keys of the same map contain the same bytes, Perl will consider these
-a duplicate key and prefer the latter.
+a duplicate key and prefer the latter. Use C<reject_duplicate_keys()> on
+L<CBOR::Free::Decoder> to reject map keys that would overwrite an earlier
+key.
 
 =item * CBOR booleans become the corresponding L<Types::Serialiser> values.
 Both CBOR null and undefined become Perl undef.

--- a/lib/CBOR/Free/Decoder.pm
+++ b/lib/CBOR/Free/Decoder.pm
@@ -15,6 +15,9 @@ CBOR::Free::Decoder
     # Enable shared/circular references:
     $decoder->preserve_references();
 
+    # Reject maps that would overwrite a decoded Perl hash key:
+    $decoder->reject_duplicate_keys();
+
 =head1 DESCRIPTION
 
 This class provides an object-oriented interface to L<CBOR::Free>’s
@@ -75,6 +78,20 @@ This I<should> be safe in contexts—such as IPC—where you control the CBOR
 serialization and can thus ensure validity of the encoded text.
 
 If in doubt, leave this off.
+
+=cut
+
+#----------------------------------------------------------------------
+
+=head2 $enabled_yn = I<OBJ>->reject_duplicate_keys( [$ENABLE] )
+
+Enables or disables rejection of duplicate map keys. It is disabled by
+default. If enabled, decoding dies with a
+L<CBOR::Free::X::DuplicateMapKey> exception when two CBOR keys would occupy
+the same key in the decoded Perl hash.
+
+Calling this method without C<$ENABLE> enables rejection. Passing a false
+value disables it. The return value indicates whether rejection is enabled.
 
 =cut
 

--- a/lib/CBOR/Free/SequenceDecoder.pm
+++ b/lib/CBOR/Free/SequenceDecoder.pm
@@ -50,6 +50,8 @@ with L<CBOR::Free::Decoder>:
 
 =item * C<naive_utf8()>
 
+=item * C<reject_duplicate_keys()>
+
 =item * C<string_decode_cbor()>
 
 =item * C<string_decode_never()>

--- a/lib/CBOR/Free/X/DuplicateMapKey.pm
+++ b/lib/CBOR/Free/X/DuplicateMapKey.pm
@@ -1,0 +1,14 @@
+package CBOR::Free::X::DuplicateMapKey;
+
+use strict;
+use warnings;
+
+use parent qw( CBOR::Free::X::Base );
+
+sub _new {
+    my ($class, $offset) = @_;
+
+    return $class->SUPER::_new("Received a duplicate CBOR map key at offset $offset.");
+}
+
+1;

--- a/t/duplicate_map_keys.t
+++ b/t/duplicate_map_keys.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::FailWarnings;
+use Test::Exception;
+
+use CBOR::Free;
+use CBOR::Free::Decoder;
+use CBOR::Free::SequenceDecoder;
+
+sub cbor {
+    my ($hex) = @_;
+    $hex =~ s/\s+//g;
+    return pack 'H*', $hex;
+}
+
+sub rejects_duplicate {
+    my ($code, $name) = @_;
+    throws_ok { $code->() } 'CBOR::Free::X::DuplicateMapKey', $name;
+    return $@;
+}
+
+my $duplicate_text = cbor('a2 61 61 01 61 61 02');
+
+is_deeply(CBOR::Free::decode($duplicate_text), { a => 2 },
+    'functional decoder keeps the later duplicate by default');
+
+my $decoder = CBOR::Free::Decoder->new();
+is_deeply($decoder->decode($duplicate_text), { a => 2 },
+    'object decoder keeps the later duplicate by default');
+ok($decoder->reject_duplicate_keys(), 'duplicate-key rejection can be enabled');
+
+my $duplicate_error = rejects_duplicate(
+    sub { $decoder->decode($duplicate_text) },
+    'duplicate text key is rejected',
+);
+
+like(
+    ref($duplicate_error) ? $duplicate_error->get_message() : '',
+    qr<offset 4>,
+    'duplicate-key error gives the second key offset',
+);
+
+my @duplicates = (
+    [ 'integer key'         => 'a2 01 01 01 02' ],
+    [ 'indefinite text key' => 'a2 7f 61 61 ff 01 7f 61 61 ff 02' ],
+    [ 'nested map'          => 'a1 61 78 a2 61 61 01 61 61 02' ],
+    [ 'undefined value'     => 'a2 61 61 f7 61 61 02' ],
+    [ 'text/binary'         => 'a2 61 61 01 41 61 02' ],
+    [ 'integer/text'        => 'a2 01 01 61 31 02' ],
+);
+
+for my $case (@duplicates) {
+    rejects_duplicate(sub { $decoder->decode(cbor($case->[1])) },
+        "$case->[0] duplicate is rejected");
+}
+
+is_deeply(
+    $decoder->decode(cbor('a2 61 61 01 61 62 02')),
+    { a => 1, b => 2 },
+    'decoder can decode distinct keys after a duplicate-key error');
+
+ok(!$decoder->reject_duplicate_keys(0), 'duplicate-key rejection can be disabled');
+is_deeply($decoder->decode($duplicate_text), { a => 2 },
+    'disabled decoder restores default behavior');
+
+my $partial = CBOR::Free::SequenceDecoder->new();
+$partial->reject_duplicate_keys();
+is($partial->give(substr($duplicate_text, 0, 5)), undef,
+    'partial duplicate key waits for its remaining bytes');
+rejects_duplicate(sub { $partial->give(substr($duplicate_text, 5)) },
+    'duplicate split across sequence chunks is rejected');
+
+done_testing;


### PR DESCRIPTION
This adds opt-in duplicate map key rejection to `CBOR::Free::Decoder` and `CBOR::Free::SequenceDecoder`, following [RFC 8949, Section 5.6](https://www.rfc-editor.org/rfc/rfc8949.html#section-5.6).

```perl
my $decoder = CBOR::Free::Decoder->new;
$decoder->reject_duplicate_keys();

# {"a": 1, "a": 2}
my $cbor = pack 'H*', 'a2616101616102';

$decoder->decode($cbor);
# Dies with CBOR::Free::X::DuplicateMapKey
```

Default decoding behavior remains unchanged. The full test suite passes.
